### PR TITLE
feat: support IBM Open XL C/C++ on z/OS

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -109,21 +109,35 @@
         ],
       }],
       [ 'OS=="zos"', {
-        'cflags': [
-          '-q64',
-          '-Wc,DLL',
-          '-qlonglong',
-          '-qenum=int',
-          '-qxclang=-fexec-charset=ISO8859-1'
+        'conditions': [
+          [ '"<!(echo $CC)" != "clang" and \
+             "<!(echo $CC)" != "ibm-clang64" and \
+             "<!(echo $CC)" != "ibm-clang"', {
+            'cflags': [
+              '-q64',
+              '-Wc,DLL',
+              '-qlonglong',
+              '-qenum=int',
+              '-qxclang=-fexec-charset=ISO8859-1'
+            ],
+            'ldflags': [
+              '-q64',
+              '<(node_exp_file)',
+            ],
+          }, {
+            'cflags': [
+              '-m64',
+            ],
+            'ldflags': [
+              '-m64',
+              '<(node_exp_file)',
+            ],
+          }],
         ],
         'defines': [
-          '_ALL_SOURCE=1',
+          '_ALL_SOURCE',
           'MAP_FAILED=-1',
-          '_UNIX03_SOURCE=1'
-        ],
-        'ldflags': [
-          '-q64',
-          '<(node_exp_file)'
+          '_UNIX03_SOURCE',
         ],
       }],
       [ 'OS=="win"', {


### PR DESCRIPTION
##### Checklist
- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Open XL C/C++ for z/OS (C invocation: clang, ibm-clang64 or ibm-clang) is LLVM-based, and doesn't support XL C/C++'s -q flags. Environment variable CC is set starting with Node.js v18 for z/OS which requires clang compiler, but CC may not be set in older versions (which required njsc or xlclang).

Accompanying change for `gyp/pylib/gyp/generator/make.py` is in https://github.com/nodejs/gyp-next/pull/178.